### PR TITLE
Small updates to the Seamless alignment vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Suggests:
     xcms (>= 4.3.4),
     Spectra (>= 1.11.10),
     MsExperiment,
-    MsIO,
+    MsIO (>= 0.0.8),
     MsBackendMetaboLights,
     readxl,
     limma,
@@ -58,7 +58,8 @@ Suggests:
     knitr,
     quarto
 Remotes:
-    sneumann/xcms
+    sneumann/xcms,
+    RforMassSpectrometry/MsIO
 URL: https://github.com/rformassspectrometry/metabonaut/, https://rformassspectrometry.github.io/metabonaut/
 BugReports: https://github.com/rformassspectrometry/metabonaut/issues/new
 BiocType: Workflow

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,22 @@
-# metabonaut 0.0.4 
+# metabonaut 0.0
+
+## Changes in 0.0.5
+
+- Require *MsIO* version 0.0.8 to allow reading of stored
+  `MsBackendMetaboLights` objects.
+- Small updates and changes to the Seamless Alignment vignette:
+  - simplify import of previously stored result object
+  - avoid using the variable name `param` for every parameter object
 
 ## Changes in 0.0.4
-- Required *alabaster.se*. 
-- In the end-to-end vignette: 
-  - Removal of Spectra data in depth visualisation to 
-    move to the Data investigation vignette 
+- Required *alabaster.se*.
+- In the end-to-end vignette:
+  - Removal of Spectra data in depth visualisation to
+    move to the Data investigation vignette
   - Removal of internal standard matching to features
-    in the Normalization part. 
-- Save an load *lcms1* and *res* object from the end-to-end workflow 
-  to be used in the Seamless Alignment vignette. Using *MsIO* and 
+    in the Normalization part.
+- Save an load *lcms1* and *res* object from the end-to-end workflow
+  to be used in the Seamless Alignment vignette. Using *MsIO* and
   *alabaster.se*
 
 

--- a/vignettes/alignment-to-external-dataset.qmd
+++ b/vignettes/alignment-to-external-dataset.qmd
@@ -56,31 +56,21 @@ if (.Platform$OS.type == "unix") {
 
 ## Load preprocessed LC-MS object
 
-First, let's load our pre-processed LC-MS object, all the steps to get this
-object is shown in the [End-to-end
+First, let's load our pre-processed LC-MS object. This *xcms* result object was
+created during the [End-to-end
 worflow](https://rformassspectrometry.github.io/metabonaut/articles/end-to-end-untargeted-metabolomics.html)
-vignette.
+vignette and is also available in the *metabonaut* R package. The result object
+(an `XcmsExperiment` object) was stored using Bioconductor's *alabaster*
+framework and we below load the object using the `readMsObject()` function
+providing the path to the stored data. The import function also takes care of
+eventually retrieving missing MS data files from the MetaboLights repository.
 
-```{r, echo = FALSE, message = FALSE, warning = FALSE}
-#' Silently loading the MetaboLights data - in case this vignette is rendered
-#' before the main workflow.
-param <- MetaboLightsParam(
-    mtblsId = "MTBLS8735",
-    assayName = paste0("a_MTBLS8735_LC-MS_positive_",
-                       "hilic_metabolite_profiling.txt"),
-    filePattern = ".mzML")
-
-tmp <- readMsObject(MsExperiment(),
-                    param,
-                    keepOntology = FALSE,
-                    keepProtocol = FALSE,
-                    simplify = TRUE)
-```
 
 ```{r}
-lcms1 <- readMsObject(XcmsExperiment(), 
-                      AlabasterParam(file.path("..", "inst","extdata", "preprocessed_lcms1")))
-
+lcms1 <- readMsObject(
+    XcmsExperiment(),
+    AlabasterParam(system.file("extdata", "preprocessed_lcms1",
+                               package = "metabonaut")))
 ```
 
 ## Load unprocessed LC-MS/MS data
@@ -89,16 +79,16 @@ Next, we will load the unprocessed LC-MS/MS data from the MetaboLights database:
 
 ```{r, message=FALSE, warning=FALSE}
 #' Load form the MetaboLights Database
-param <- MetaboLightsParam(mtblsId = "MTBLS8735",
-                           assayName = paste0("a_MTBLS8735_LC-MSMS_positive_",
-                           "hilic_metabolite_profiling.txt"),
-                           filePattern = ".mzML")
+mlp <- MetaboLightsParam(mtblsId = "MTBLS8735",
+                         assayName = paste0("a_MTBLS8735_LC-MSMS_positive_",
+                                            "hilic_metabolite_profiling.txt"),
+                         filePattern = ".mzML")
 
 lcms2 <- readMsObject(MsExperiment(),
-                     param,
-                     keepOntology = FALSE,
-                     keepProtocol = FALSE,
-                     simplify = TRUE)
+                      mlp,
+                      keepOntology = FALSE,
+                      keepProtocol = FALSE,
+                      simplify = TRUE)
 
 ```
 
@@ -125,11 +115,11 @@ sampleData(lcms2)[, c("derived_spectra_data_file",
 ```
 
 We will only keep the MS runs (not MS/MS) and remove pooled samples, focusing on
-samples A and E that are common to both runs.
+samples *A* and *E* that are common to both runs.
 
 ```{r}
 # Only keep MS run
-lcms2 <- lcms2[!grepl("MSMS", sampleData(lcms2)$derived_spectra_data_file),]
+lcms2 <- lcms2[!grepl("MSMS", sampleData(lcms2)$derived_spectra_data_file), ]
 ```
 
 Before alignment, ensure the retention time (RT) ranges match between the
@@ -163,7 +153,7 @@ bpc2 <- chromatogram(lcms2, aggregationFun = "max", msLevel = 1)
 Compare run1 sample A with run2 sample A
 
 ```{r ini-bpc1}
-plot(bpc1[1,1], col = "#00000080",
+plot(bpc1[1, 1], col = "#00000080",
      main = "BPC sample A LC-MS vs A LC-MS/MS", lwd = 1.5, peakType = "none")
 grid()
 points(rtime(bpc2[1, 1]), intensity(bpc2[1, 1]), col = "#0000ff80", type = "l")
@@ -188,11 +178,11 @@ Perform peak detection and refining before alignment, as detailed in the
 end-to-end vignette. The same setting were applied.
 
 ```{r quick-proc, message=FALSE, warning=FALSE}
-param <- CentWaveParam(peakwidth = c(1, 8), ppm = 15, integrate = 2)
-lcms2 <- findChromPeaks(lcms2, param = param, chunkSize = 2)
-param <- MergeNeighboringPeaksParam(expandRt = 2.5, expandMz = 0.0015,
+cwp <- CentWaveParam(peakwidth = c(1, 8), ppm = 15, integrate = 2)
+lcms2 <- findChromPeaks(lcms2, param = cwp, chunkSize = 2)
+mnpp <- MergeNeighboringPeaksParam(expandRt = 2.5, expandMz = 0.0015,
                                     minProp = 0.75)
-lcms2 <- refineChromPeaks(lcms2, param = param, chunkSize = 2)
+lcms2 <- refineChromPeaks(lcms2, param = mnpp, chunkSize = 2)
 ```
 
 ## Alignment
@@ -216,32 +206,32 @@ head(lcms1_mz_rt)
 nrow(lcms1_mz_rt)
 ```
 
-This is what the `lamas` input should look like for alignment. In terms of how
+This is what the *lamas* input should look like for alignment. In terms of how
 this method works, the alignment algorithm matches chromatographic peaks from
 the experimental data to the lamas, fitting a model based on this match to
 adjust their retention times and minimize differences between the two datasets.
 
-Now we can define our `param` object `LamaParama` to prepare for the alignment.
-Parameters such as `tolerance`, `toleranceRt`, and `ppm` relate to the matching
-between chromatographic peaks and lamas. Other parameters are related to the
-type of fitting generated between these data points. More details on each
-parameter and the overall method can be found by searching `?adjustRtime`. Below
-is an example using default parameters.
+Now we can define our parameter object `LamaParama` to prepare for the
+alignment.  Parameters such as `tolerance`, `toleranceRt`, and `ppm` relate to
+the matching between chromatographic peaks and lamas. Other parameters are
+related to the type of fitting generated between these data points. More details
+on each parameter and the overall method can be found by searching
+`?adjustRtime`. Below is an example using default parameters.
 
 ```{r}
-param <- LamaParama(lamas = lcms1_mz_rt, method = "loess", span = 0.5,
-                    outlierTolerance = 3, zeroWeight = 10, ppm =20,
-                    tolerance = 0, toleranceRt = 20, bs = "tp")
+lp <- LamaParama(lamas = lcms1_mz_rt, method = "loess", span = 0.5,
+                 outlierTolerance = 3, zeroWeight = 10, ppm =20,
+                 tolerance = 0, toleranceRt = 20, bs = "tp")
 ```
 
 The `matchLamaChromPeaks()` function facilitates the assessment of how well the
-`lamas` correspond with the chromatographic peaks in each file. We then extract
+*lamas* correspond with the chromatographic peaks in each file. We then extract
 the matched results using the `matchedRtimes()` function. This will be used
 later to evaluate the alignment.
 
 ```{r}
-param <- matchLamasChromPeaks(lcms2, param = param)
-ref_vs_obs <- matchedRtimes(param)
+lp <- matchLamasChromPeaks(lcms2, param = lp)
+ref_vs_obs <- matchedRtimes(lp)
 ```
 
 Now we can adjust the retention time of the LC-MS/MS dataset using the
@@ -249,7 +239,7 @@ Now we can adjust the retention time of the LC-MS/MS dataset using the
 
 ```{r warning=FALSE}
 #' input into `adjustRtime()`
-lcms2 <- adjustRtime(lcms2, param = param)
+lcms2 <- adjustRtime(lcms2, param = lp)
 lcms2 <- applyAdjustedRtime(lcms2)
 ```
 
@@ -260,7 +250,7 @@ We extract the base peak chromatogram (BPC) of our aligned object:
 ```{r, message=FALSE}
 #' evaluate the results with BPC
 bpc2_adj <- chromatogram(lcms2, aggregationFun = "max",
-                              msLevel = 1)
+                         msLevel = 1)
 ```
 
 ### Visualizing Alignment Quality
@@ -313,7 +303,7 @@ particularly well done. Specifically, the regions right before and after 150
 seconds show substantial improvement.
 
 Below is a visualization of the distribution of chromatographic peaks matched to
-anchor peaks (Lamas) for Sample A. The red vertical lines represent the
+anchor peaks (lamas) for Sample A. The red vertical lines represent the
 positions of these matched peaks.
 
 ```{r, message = FALSE, warning = FALSE}
@@ -373,7 +363,7 @@ chromatographic peaks along with the fitted model line.
 
 ```{r warning=FALSE}
 #' Access summary of matches and model information
-summary <- summarizeLamaMatch(param)
+summary <- summarizeLamaMatch(lp)
 summary
 
 #' Coverage for each file
@@ -383,7 +373,7 @@ summary$Matched_peaks / summary$Total_peaks * 100
 summary$Model_summary[[1]]
 
 #' Plot obs vs. lcms1 with fitting line
-plot(param, index = 1L, main = "ChromPeaks versus Lamas for sample A",
+plot(lp, index = 1L, main = "ChromPeaks versus Lamas for sample A",
      colPoint = "red")
 abline(0, 1, lty = 3, col = "grey")
 grid()


### PR DESCRIPTION
- Require *MsIO* version 0.0.8 to allow reading of stored
  `MsBackendMetaboLights` objects.
- Small updates and changes to the Seamless Alignment vignette:
  - simplify import of previously stored result object
  - avoid using the variable name `param` for every parameter object