### PR TITLE
Add missing library(knitr) to dependencies in the workflow vignette

### DIFF
--- a/vignettes/a-end-to-end-untargeted-metabolomics.qmd
+++ b/vignettes/a-end-to-end-untargeted-metabolomics.qmd
@@ -52,6 +52,7 @@ Our workflow is therefore based on the following dependencies:
 
 ```{r packages-used, message=FALSE, warning=FALSE}
 ## Data Import and handling
+library(knitr)
 library(readxl)
 library(MsExperiment)
 library(MsIO)


### PR DESCRIPTION
This `library(knitr)` is required to prevent `could not find function "kable"` error in 
```
sampleData(lcms1)[, c("Derived_Spectral_Data_File",
                      "Characteristics[Sample type]",
                      "Factor Value[Phenotype]",
                      "Sample Name",
                      "Factor Value[Age]")] |>
    kable(format = "pipe")
```
.