### PR TITLE
Fix versions for packages installed from GitHub and update installation description

### DIFF
--- a/.github/workflows/docker-push.yaml
+++ b/.github/workflows/docker-push.yaml
@@ -40,7 +40,7 @@ jobs:
             github_pat=${{ secrets.GITHUB_TOKEN }}
           tags: |
             rformassspectrometry/metabonaut:latest
-            rformassspectrometry/metabonaut:RELEASE_3_23
+            rformassspectrometry/metabonaut:v1.6.2
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Metabonaut
 Title: Exploring and Analyzing LC-MS Data
-Version: 1.6.1
+Version: 1.6.2
 Authors@R:
     c(person(given = "Philippine", family = "Louail",
             email = "philippine.louail@outlook.com",
@@ -98,9 +98,9 @@ Suggests:
     RmzTabM,
     zen4R
 Remotes:
-    RforMassSpectrometry/MsIO,
-    RforMassSpectrometry/RuSirius,
-    RforMassSpectrometry/RmzTabM@gabri,
+    RforMassSpectrometry/MsIO@a669fa1303a023161581b7a16caed3ed20a43299,
+    RforMassSpectrometry/RuSirius@cf0c6ed3bb031495861c0e2964fef6a7debc2988,
+    RforMassSpectrometry/RmzTabM@96e79f180031485cbf581971f3f3d8cac6979379,
     sirius-ms/sirius-client-openAPI/client-api_r/generated@2c983e6
 URL: https://github.com/rformassspectrometry/Metabonaut/, https://rformassspectrometry.github.io/Metabonaut/
 BugReports: https://github.com/rformassspectrometry/Metabonaut/issues/new

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Encoding: UTF-8
 LazyData: false
 Roxygen: list(markdown = TRUE)
 Depends:
-    R (>= 4.5),
+    R (>= 4.6),
     BiocParallel (>= 1.8.0)
 Suggests:
     alabaster.se,

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN rm -rf /home/rstudio/scripts /home/rstudio/vignettes/.quarto
 ## with the Remotes field in DESCRIPTION, otherwise main is installed over it.
 RUN --mount=type=secret,id=github_pat \
     export GITHUB_PAT="$(cat /run/secrets/github_pat 2>/dev/null || true)" && \
-    Rscript -e "install.packages('remotes'); BiocManager::install(c('RforMassSpectrometry/MsIO', 'RforMassSpectrometry/RmzTabM@gabri', 'MsBackendMetaboLights', 'mzR') , ask = FALSE, dependencies = c('Depends', 'Imports'), build_vignettes = FALSE)"
+    Rscript -e "install.packages('remotes'); BiocManager::install(c('RforMassSpectrometry/MsIO@a669fa1303a023161581b7a16caed3ed20a43299', 'RforMassSpectrometry/RmzTabM@96e79f180031485cbf581971f3f3d8cac6979379', 'MsBackendMetaboLights', 'mzR') , ask = FALSE, dependencies = c('Depends', 'Imports'), build_vignettes = FALSE)"
 
 ## Use SpectriPy with virtual env to avoid need to install miniconda
 ENV SPECTRIPY_USE_CONDA="FALSE"
@@ -38,7 +38,7 @@ USER rstudio
 RUN --mount=type=secret,id=github_pat,uid=1000 \
     export GITHUB_PAT="$(cat /run/secrets/github_pat 2>/dev/null || true)" && \
     Rscript -e "install.packages('reticulate')" && \
-    Rscript -e "BiocManager::install('RforMassSpectrometry/SpectriPy', ask = FALSE, dependencies = c('Depends', 'Imports'), build_vignettes = FALSE)" && \
+    Rscript -e "BiocManager::install('SpectriPy', ask = FALSE, dependencies = c('Depends', 'Imports'), build_vignettes = FALSE)" && \
     Rscript -e "library(MsBackendMetaboLights);Spectra('MTBLS8735', source = MsBackendMetaboLights())"
 
 ## Install the current package and build its vignettes in two steps.
@@ -80,5 +80,4 @@ RUN chmod a+x /etc/cont-init.d/03_sirius
 ## Install RuSirius (R interface to Sirius) for interactive use
 RUN --mount=type=secret,id=github_pat \
     export GITHUB_PAT="$(cat /run/secrets/github_pat 2>/dev/null || true)" && \
-    Rscript -e "BiocManager::install('RforMassSpectrometry/RuSirius', ask = FALSE, dependencies = c('Depends', 'Imports'), build_vignettes = FALSE)"
-
+    Rscript -e "BiocManager::install('RforMassSpectrometry/RuSirius@cf0c6ed3bb031495861c0e2964fef6a7debc2988', ask = FALSE, dependencies = c('Depends', 'Imports'), build_vignettes = FALSE)"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Metabonaut 1.6
 
+## Changes in 1.6.2
+
+- Fix Docker image to lock packages installed from GitHub to a specific
+  commit/version: *MsIO* (0.0.17), *RmzTabM* (0.99.1), *RuSirius* (1.0.4).
+- Use *SpectriPy* from Bioconductor 3.23 release branch.
+- Update installation and usage descriptions.
+
 ## Changes in 1.6.1
 
 - Install *RmzTabM* in the docker image for the mzTab-M vignette.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
   commit/version: *MsIO* (0.0.17), *RmzTabM* (0.99.1), *RuSirius* (1.0.4).
 - Use *SpectriPy* from Bioconductor 3.23 release branch.
 - Update installation and usage descriptions.
+- Fix typos and formatting errors in the *Using and Creating Metabolomics Data
+  Annotation Resources* and expand some textual passages.
 
 ## Changes in 1.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 - Update installation and usage descriptions.
 - Fix typos and formatting errors in the *Using and Creating Metabolomics Data
   Annotation Resources* and expand some textual passages.
+- Fix typos and expand descriptions in the *LC-MS/MS Data Annotation using R and
+  Python* vignette.
 
 ## Changes in 1.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
   Annotation Resources* and expand some textual passages.
 - Fix typos and expand descriptions in the *LC-MS/MS Data Annotation using R and
   Python* vignette.
+- Fix typos, format and reformulate some descriptions in the *mzTab-M file
+  format: import-export of mzTab-M 2.1 files from SummarizedExperiment*.
 
 ## Changes in 1.6.1
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,13 @@ remain stable over time, allowing you to run all vignettes together as
 one comprehensive **super-vignette**.
 
 -   **Major updates** will be documented here.
-    -   Metabonaut now works with a stable version of Bioconductor
-        (3.23)
+    -   Metabonaut (1.6.2) now works with a stable version of Bioconductor
+        (3.23). Packages not yet included in Bioconductor are installed from
+        GitHub: [*MsIO*](https://github.com/RforMassSpectrometry/MsIO) (version
+        0.0.17), [*RmzTabM*](https://github.com/RforMassSpectrometry/RmzTabM)
+        (version 0.99.1),
+        [*RuSirius*](https://github.com/RforMassSpectrometry/RuSirius) (version
+        1.0.4).
 -   **Minor updates** can be found in the
     [News section](https://rformassspectrometry.github.io/Metabonaut/news/index.html).
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ actively refining the website. If you're experiencing any issues:
 🐛 If the issue persists, report it with a **reproducible example** on
 [**GitHub Issues**](https://github.com/rformassspectrometry/Metabonaut/issues).
 
-Currently, there are **no known issues** with the code.
+Currently, all vignettes run without problems.
 
 ---
 

--- a/vignettes/SpectriPy-tutorial-metabonaut.qmd
+++ b/vignettes/SpectriPy-tutorial-metabonaut.qmd
@@ -9,8 +9,12 @@ vignette: >
   %\VignetteKeywords{Mass Spectrometry, MS, MSMS, Metabolomics, Infrastructure, Quantitative}
   %\VignettePackage{SpectriPy}
   %\VignetteEngine{quarto::html}
-  %\VignetteDepends{SpectriPy,pander,reticulate,Spectra}
+  %\VignetteDepends{SpectriPy,pander,reticulate,Spectra,BiocStyle}
 ---
+
+```{r setup}
+library(BiocStyle)
+```
 
 # Introduction
 
@@ -36,18 +40,24 @@ in this tutorial originates from a small *in-house* reference library (provided
 in MGF format) available in the *SpectriPy* package.
 
 The analysis in this document is performed using R and Python code chunks. A
-comment *\#' R session:* or *\#' Python session:* is used for easier
-distinction of these.
+comment `#' R session:` or `#' Python session:` is used for easier distinction
+of these. Additional examples of combined R+Python analyses are also provided in
+the Metabonaut *Using and Creating Metabolomics Data Annotation Resources*
+vignette.
 
 # Load *SpectriPy*
 
-Load the required R *SpectriPy* package. If you already have a Python
-environment opened, please restart your Integrated Development Environment and
-run this as a first command, to load the required package *reticulate* and
-setup the conda environment 'r-spectripy' correctly. Please see the [Detailed
+Load the required R `r Biocpkg("SpectriPy") package. First-time loading of the
+package will also configure the Python environment and install all required
+Python libraries.
+
+::: {.callout-note appearance = "minimal"}
+ℹ️ See also the [Detailed
 information on installation and
 configuration](https://rformassspectrometry.github.io/SpectriPy/articles/detailed-installation-configuration.html)
-document for other options.
+vignette for alternatives, e.g. using a system Python installation with
+*SpectriPy*.
+:::
 
 ```{r}
 #| warning: false
@@ -65,7 +75,7 @@ Workflow for untargeted LC-MS/MS Metabolomics Data Analysis in
 R](https://rformassspectrometry.github.io/Metabonaut/articles/end-to-end-untargeted-metabolomics.html).
 
 First, we load the `Spectra` object with the MS2 spectra of the unknown
-features found to be significant in the "Differential abundance analysis", see
+features found to be significant in the *Differential abundance analysis*, see
 section [MS2-based
 annotation](https://rformassspectrometry.github.io/Metabonaut/articles/end-to-end-untargeted-metabolomics.html#differential-abundance-analysis).
 This `Spectra` object is shared as part of the *Metabonaut* package.
@@ -91,9 +101,8 @@ ms2_ctr_fts$feature_id[1]
 
 # Filter query data
 
-To ensure this `Spectra` object only contains MS2 data, we filter to only MS2
-spectra with more than 2 fragment peaks per spectrum using some classical
-filtering functions from the *Spectra* package.
+To ensure this `Spectra` object to contain only MS2 data, we filter the data to
+MS level 2 and restrict in addition to spectra with more than 2 fragment peaks.
 
 ```{r}
 #' R session:
@@ -108,7 +117,7 @@ ms2_ctr_fts
 
 # Load reference MS2 data
 
-As the *in-house* spectral library, we import a small test data file in MGF
+As the *reference* spectral library, we import a small test data file in MGF
 format. This file is part of the *SpectriPy* package and we below define its
 path on the local computer.
 
@@ -119,10 +128,16 @@ path on the local computer.
 mgf_file <- system.file("extdata", "mgf", "test.mgf", package = "SpectriPy")
 ```
 
-The loading of this file is then performed using the Python *matchms* library.
-The variable with the MGF file name can be accessed in the associated Python
-session using `r.mgf_file`. The loaded object is a Python list of
-`matchms.Spectrum` objects.
+We load this file next using the Python *matchms* library.  The variable with
+the MGF file name defined in R can be accessed in the associated Python session
+using `r.mgf_file`. The loaded object is a Python list of `matchms.Spectrum`
+objects.
+
+::: {.callout-note appearance = "minimal"}
+ℹ️ In *reticulate*-based shared R/Python sessions R variables can be accessed in
+Python using the prefix `r.` while Python attributes can be accessed from R
+using `py$`.
+:::
 
 ```{python}
 #| warning: false
@@ -195,9 +210,9 @@ ms2_ctr_fts_py[0]
 # Filter the reference library
 
 Before we run the spectral comparisons of our query data to the MGF reference
-library, we first apply some MS2 processing from *matchms*. Default filtering
-from *matchms* is performed to standardize ion mode, correct charge and more.
-See the [matchms filtering
+library, we first apply some MS2 processing from the Python *matchms*
+library. Default filtering from *matchms* is performed to standardize ion mode,
+correct charge and more. See the [matchms filtering
 documentation](https://matchms.readthedocs.io/en/latest/api/matchms.filtering.html).
 Also, we keep only reference spectra with a precursor m/z as the similarity
 algorithm we use later requires spectra to have a precursor m/z.
@@ -232,16 +247,14 @@ len(clean_mgf_py)
 We calculate the pairwise spectral similarity between the query spectra and the
 reference library spectra using Python's *matchms* library.
 
-Here, we use the modified cosine spectral similarity algorithm from *matchms*,
-from source
-[matchms](https://github.com/matchms/matchms/blob/master/README.rst). This
+Here, we use the modified cosine spectral similarity algorithm. This
 algorithm can easily be exchanged for another spectral similarity calculation
 from *matchms* (see
 [here](https://matchms.readthedocs.io/en/latest/api/matchms.similarity.html)).
 
 Since *matchms* version 0.32, this algorithm is called `ModifiedCosineGreedy`
 (it was named `ModifiedCosine` before). The implementation solves the peak
-assignment between two spectra in a *greedy* way, i.e. it repeatedly takes the
+assignment between two spectra in a *greedy* way, i.e., it repeatedly takes the
 highest scoring peak pair, which is fast but only an approximation of the
 optimal assignment. *matchms* also provides `ModifiedCosineHungarian`, which
 computes the exact assignment at the cost of longer run times. For a typical
@@ -284,9 +297,9 @@ sim_matchms = sim_matchms.T
 sim_matchms.shape
 ```
 
-Next, we create a data frame with per queried spectrum from our unknown
-variables, the compound name of the higest matching spectra from the reference
-library and the corresponding similarity score.
+Next, we create a data frame with one row per queried spectrum adding the
+compound name of the highest matching spectra from the reference library and the
+corresponding similarity score.
 
 ```{python}
 #' Python session:
@@ -319,12 +332,14 @@ df = pd.DataFrame(results)
 df.head()
 ```
 
-\[!\] **Caution**: As the higest score is taken as criteria for the annotation,
+::: {.callout-note appearance="minimal"}
+⚠️  As the higest score is taken as criteria for the annotation,
 a lot of caution is needed evaluation the trueness of the match. A low score is
 not reliable, as the similarity algorithm will calculate a score for each pair
 of spectra. Therefore, a match will always be found. In addition, if your
 unknown compound is absent in the reference library, it will match wrongly to
 another compound that is present in the database.
+:::
 
 Below we filter the results retaining only matches with a similarity value
 above 0.6. Above this value, the potential annotations need to be validated
@@ -336,6 +351,8 @@ using e.g. rerunning samples in the presence of commercial standards.
 #' Keep only rows where score >= 0.6
 df_filtered = df[df["ModifiedCosineGreedy_score"] >= 0.6]
 ```
+
+The table below shows these matches:
 
 ```{r, results = "asis"}
 #' R session:

--- a/vignettes/creating-using-annotation-resources.qmd
+++ b/vignettes/creating-using-annotation-resources.qmd
@@ -49,9 +49,9 @@ future work toward harmonized formats such as
 # Accessing and using spectral libraries
 
 Spectral libraries come in different formats. Packages from the
-*RforMassSpectrometry* initiative (`r Biocpkg("MsBackendMgf")`, `r
-Biocpkg("MsBackendMsp")`, `r Biocpkg("MsBackendMassbank")`, `r
-Biocpkg("CompoundDb")`) parse these formats into `Spectra` objects ready for
+*RforMassSpectrometry* initiative (`r Biocpkg("MsBackendMgf")`,
+`r Biocpkg("MsBackendMsp")`, `r Biocpkg("MsBackendMassbank")`,
+`r Biocpkg("CompoundDb")`) parse these formats into `Spectra` objects ready for
 R-based workflows. Below we load GNPS and MassBank libraries for LC-MS/MS
 annotation.
 
@@ -59,14 +59,14 @@ annotation.
 
 [GNPS2](https://gnps2.org) provides MS/MS spectral libraries, integrating data
 from sources such as [MassBank](https://massbank.eu/MassBank/) and
-[MoNA](https://mona.fiehnlab.ucdavis.edu/). Libraries are available as MGF, MSP,
-or JSON from the [GNPS2 site](https://external.gnps2.org/gnpslibrary) and on
-Zenodo or Figshare with their own DOIs.
+[MoNA](https://mona.fiehnlab.ucdavis.edu/). Libraries are available in MGF, MSP,
+or JSON format from the [GNPS2 site](https://external.gnps2.org/gnpslibrary) and
+on Zenodo or Figshare with their own data set-specific DOIs.
 
 Here we download the GNPS2 drug library from
 [Zenodo](https://doi.org/10.5281/zenodo.13892288), a centralized collection of
-drug spectra with pharmacologic metadata [@zhao_resource_2025]. We fetch all v4
-resources (DOI: 10.5281/zenodo.17232042) to a temporary folder.
+drug spectra with pharmacologic metadata [@zhao_resource_2025]. We fetch all
+version 4 (v4) resources (DOI: 10.5281/zenodo.17232042) to a temporary folder.
 
 ```{r, message = FALSE}
 library(Spectra)
@@ -91,10 +91,10 @@ readLines(mgf_fl, n = 25)
 The MGF format allows having additional fields to provide spectra metadata on
 top of mandatory fields such as *PEPMASS* (for precursor *m/z*) or *CHARGE* (for
 the precursor's charge). MGF files can be imported into a `Spectra` object using
-the `r Biocpkg("MsBackendMgf")`, which supports import of all metadata fields,
-renaming and mapping them to specific spectra variables. Below we define such a
-variable name mapping to map e.g. *MSLEVEL* to the spectra variable `msLevel`
-and *NAME* to *spectrum_name*.
+the `r Biocpkg("MsBackendMgf")` package, which supports import of all metadata
+fields, renaming and mapping them to specific spectra variables. Below we
+define such a variable name mapping to map e.g. *MSLEVEL* to the spectra
+variable *msLevel* and *NAME* to *spectrum_name*.
 
 ```{r}
 library(MsBackendMgf)
@@ -119,7 +119,7 @@ drug_ms2 <- Spectra(mgf_fl, source = MsBackendMgf(), mapping = svm)
 ```
 
 We convert `IONMODE` from `"Positive"`/`"Negative"` to the standard `polarity`
-encoding (`1`/`0`).
+encoding (`1`/`0`) used by the R packages.
 
 ```{r}
 drug_ms2$polarity[which(drug_ms2$IONMODE == "Positive")] <- 1L
@@ -175,9 +175,9 @@ plotSpectra(drug_ms2[1:4])
 The number of fragment peaks per spectrum was thus reduced and intensities are
 now relative to the total intensity sum.
 
-This `Spectra` object can now be used to match MS/MS spectra from the *Complete
-end-to-end LC-MS/MS metabolomics data analysis* workflow. We load the example
-`Spectra` object below.
+This `Spectra` object can now be used as a *reference data* to match MS/MS
+spectra from the *Complete end-to-end LC-MS/MS metabolomics data analysis*
+workflow. We load the example `Spectra` object below.
 
 ```{r}
 #' load the MS2 spectra for significant features
@@ -208,16 +208,16 @@ caffeine.
 res$target_spectrum_name |> unique()
 ```
 
-To summarize, through packages such as `r Biocpkg("MsBackendMgf")`, `r
-Biocpkg("MsBackendMsp")` it is easily possible to integrate public (or in-house)
-spectral reference libraries in MGF or MSP file format into R-based annotation
-workflows.
+To summarize, through packages such as `r Biocpkg("MsBackendMgf")`,
+or `r Biocpkg("MsBackendMsp")` it is easily possible to integrate public (or
+in-house) spectral reference libraries in MGF or MSP file format into R-based
+annotation workflows.
 
 ### Importing and cleaning GNPS MGF files using Python's *matchms* library
 
 Alternatively, it is possible to import and clean the GNPS MGF file in Python
-with *matchms* and access it in R through `MsBackendPy` from the `r
-Biocpkg("SpectriPy")` package [@graeve_spectripy_2025].
+with *matchms* and access it in R through `MsBackendPy` from the
+`r Biocpkg("SpectriPy")` package [@graeve_spectripy_2025].
 
 ```{r}
 #' load the required SpectriPy package; this will also install
@@ -226,9 +226,12 @@ library(SpectriPy)
 ```
 
 We next import the MGF file in Python using the *matchms* library
-[@huber_matchms_2020].
+[@huber_matchms_2020] (source code blocks like the one below with the comment
+`#' Python` contain code in Python and are executed and evaluated through the
+Python interpreter).
 
 ```{python}
+#' Python
 import matchms
 from matchms.importing import load_from_mgf
 
@@ -241,6 +244,7 @@ Next we clean and harmonize metadata with *matchms* filters. See the
 or [@de_jonge_reproducible_2024] for options.
 
 ```{python, warning = FALSE}
+#' Python
 from matchms.filtering import default_filters, clean_adduct
 
 #' apply filters to clean the spectra metadata
@@ -263,7 +267,7 @@ s_py <- Spectra("s_py_clean", source = MsBackendPy())
 spectraVariables(s_py)
 ```
 
-The *adduct* information was now harmonized by the filtering workflow in Python:
+The *adduct* information was harmonized by the filtering workflow in Python:
 
 ```{r}
 #' get the unique adduct types
@@ -313,11 +317,11 @@ mb
 ```
 
 The result is returned as a `CompDb` object from the `r Biocpkg("CompoundDb")`
-package which can be directly used with the annotation functions from the `r
-Biocpkg("MetaboAnnotation")` package. While this approach is convenient and
-fast, not all MassBank releases are available through *AnnotationHub*.
+package which can be directly used with the annotation functions from the
+`r Biocpkg("MetaboAnnotation")` package. While this approach is convenient and
+fast, not all MassBank releases are available through *AnnotationHub* yet.
 
-Alternatively, download MassBank data from the [MassBank GitHub
+Alternatively, we can download MassBank data from the [MassBank GitHub
 page](https://github.com/MassBank/MassBank-data/releases) or Zenodo. DOI
 [10.5281/zenodo.3378723](https://doi.org/10.5281/zenodo.3378723) points to the
 latest release. Here we fetch release *2025.10* via DOI 10.5281/zenodo.17432277:
@@ -329,7 +333,7 @@ library(zen4R)
 doi <- "10.5281/zenodo.17432277"
 
 pth <- tempdir()
-download_zenodo(doi, path = pth, quiet = TRUE, timeout = 600)
+download_zenodo(doi, path = pth, quiet = TRUE, timeout = 6000)
 dir(pth)
 ```
 
@@ -348,7 +352,7 @@ length(fls)
 ```
 
 Each file holds one spectrum with compound, instrument, and provider metadata in
-MassBank format. We import the full release with `MsBackendMassbank()` into a
+MassBank format. We import the full data set with `MsBackendMassbank()` into a
 `Spectra` object.
 
 ```{r, message = FALSE}
@@ -370,7 +374,7 @@ spectraVariables(s_mb)
 The `metaBlocks` parameter can be used to enable import of extra
 metadata. MassBank metadata are *generally* more standardized and include more
 compound information (e.g., formula, exact mass). We now match the end-to-end
-vignette spectra against MassBank 2025.10 with `matchSpectra()`.
+vignette spectra against MassBank 2025.10 with *MetaboAnnotation*'s `matchSpectra()`.
 
 ```{r}
 #' match the experimental spectra against the GNPS2 drug library
@@ -405,10 +409,10 @@ unlink(dir(pth, full.names = TRUE), recursive = TRUE)
 # Creating or expanding annotation resources
 
 Public MGF/MSP libraries can be imported into `Spectra` and exported again.
-Alternatively, annotations can be stored in SQL databases *via* the `r
-Biocpkg("CompoundDb")` package, which defines a simple database schema for small
-compounds and MS data. Here we build a database from the GNPS2 drug library; see
-the vignette [*Creating CompoundDb annotation
+Alternatively, annotations can be stored in SQL databases *via* the
+`r Biocpkg("CompoundDb")` package, which defines a simple but flexible database
+schema for small compounds and MS data. Here we build a database from the GNPS2
+drug library; see the vignette [*Creating CompoundDb annotation
 resources*](https://rformassspectrometry.github.io/CompoundDb/articles/create-compounddb.html)
 for more examples.
 
@@ -448,7 +452,7 @@ To define the names for the compounds we first parse (and then strip) the adduct
 information from the spectrum name. The pattern defined below finds all
 sub-strings that start with a white space, followed by no, one or two `"["`, an
 `"M"` (or `"2M"` etc) with a `"+"` or a `"-"` followed by any character until
-the end of the string. This patter *should* allow to find all adduct
+the end of the string. This pattern *should* allow to find all adduct
 definitions, even if they don't follow the standard nomenclature.
 
 ```{r}
@@ -749,6 +753,13 @@ harmonizing metadata and annotations across sources. Interpretation benefits
 from cleaned, standardized information. Efforts such as
 [@de_jonge_reproducible_2024] help, but broader standardization of data and
 naming conventions is still needed.
+
+The selection of the annotation reference resource, subset of version has an
+impact on the annotation result. Also, not all annotation resources use
+versioning and their content can therefore change on a daily basis preventing
+reproducibility. Building and reporting versioned, self-contained and
+re-distributable annotation assets, as described in this vignette, can help
+guaranteeing transparent and reproducible results.
 
 # Outlook
 

--- a/vignettes/creating-using-annotation-resources.qmd
+++ b/vignettes/creating-using-annotation-resources.qmd
@@ -76,7 +76,7 @@ doi <- "10.5281/zenodo.17232042" # v4
 
 #' download all data related to the DOI
 pth <- tempdir()
-download_zenodo(doi, path = pth, quiet = TRUE, timeout = 600)
+download_zenodo(doi, path = pth, quiet = TRUE, timeout = 6000)
 dir(pth)
 ```
 

--- a/vignettes/creating-using-annotation-resources.qmd
+++ b/vignettes/creating-using-annotation-resources.qmd
@@ -243,7 +243,8 @@ Next we clean and harmonize metadata with *matchms* filters. See the
 [*matchms.filtering* documentation](https://matchms.readthedocs.io/en/latest/api/matchms.filtering.html)
 or [@de_jonge_reproducible_2024] for options.
 
-```{python, warning = FALSE}
+```{python}
+#| warning: false
 #' Python
 from matchms.filtering import default_filters, clean_adduct
 
@@ -417,7 +418,7 @@ resources*](https://rformassspectrometry.github.io/CompoundDb/articles/create-co
 for more examples.
 
 ::: {.callout-note appearance="minimal"}
-The *CompDb* database layout defines 3 main database tables, one for compound
+ℹ️ The *CompDb* database layout defines 3 main database tables, one for compound
 annotations, one for spectra metadata and one to store the actual mass (or
 fragment) peaks. These tables are linked with each other through specific
 identifier columns (*primary/foreign keys*): each table has its own *ID* column

--- a/vignettes/generation_of_mzTabM_file.qmd
+++ b/vignettes/generation_of_mzTabM_file.qmd
@@ -1,5 +1,5 @@
 ---
-title: "mzTab-M file format: import-export of mzTab-M 2.1 files from Summarized Experiment"
+title: "mzTab-M file format: import-export of mzTab-M 2.1 files from SummarizedExperiment"
 author: "Gabriele Tomè, Philippine Louail, Johannes Rainer"
 format: html
 tbl-cap-location: bottom
@@ -8,7 +8,7 @@ minimal: true
 bibliography: references.bib
 date: 'Compiled: `r format(Sys.Date(), "%B %d, %Y")`'
 vignette: >
-  %\VignetteIndexEntry{mzTab-M file format: import-export of mzTab-M 2.1 files from Summarized Experiment}
+  %\VignetteIndexEntry{mzTab-M file format: import-export of mzTab-M 2.1 files from SummarizedExperiment}
   %\VignetteEngine{quarto::html}
   %\VignetteEncoding{UTF-8}
 ---
@@ -26,18 +26,16 @@ knitr::opts_knit$set(root.dir = './')
 }
 ```
 
-
 # Introduction
 
-The file *mzTab-M* is a lightweight, tab-delimited file format for reporting
-quantitative results from metabolomics/lipidomics approaches. This format aims
+*mzTab-M* is a lightweight, tab-delimited file format for reporting
+quantitative results from metabolomics/lipidomics experiments. This format aims
 to give local LIMS systems and MS metabolomics repositories a simple way to
 share and combine basic information.
 
-This document shows how to export and import a mzTab-M file into R via the
-package [RmzTabM](https://github.com/rformassspectrometry/RmzTabM), which
-provides the API and core functionality to read and write files in mzTab-M
-format.
+This document shows how to export and import a mzTab-M file into R *via* the
+`r Biocpkg("RmzTabM")` Bioconductor package, which provides the API and core
+functionality to read and write files in this format.
 
 The *RmzTabM* package supports mzTab-M version **2.1**.
 
@@ -66,7 +64,7 @@ molecules reported in the SML section. The SML is supposed to be a subset of
 the SMF table. The structure and relationship between rows in these different
 tables is defined by the mzTab-M standard and follows strict rules.
 All mzTab-M files are validated using either the [online](https://apps.lifs-tools.org/mztabvalidator/)
-or local Java validator to ensure compliance. In RmzTabM, this validation is
+or local Java validator to ensure compliance. In *RmzTabM*, this validation is
 executed locally via the offline Java tool.
 
 # Package
@@ -79,46 +77,49 @@ library(xcms)
 library(SummarizedExperiment)
 ```
 
-# Export of a SummarizedExperiment into mzTab-M file
+# Export of a `SummarizedExperiment` to mzTab-M
 
 ## Data import
 
 In this document we export the preprocessed data set used in the *Metabonaut*
-[end-to-end metabolomics data workflow](https://rformassspectrometry.github.io/metabonaut/articles/end-to-end-untargeted-metabolomics.html)
-in mzTab-M format, based on the Metabolights data set *MTBLS8735*. After
-collecting all necessary experimental metadata, we export this result object
-as a mzTab-M file with only the metadata and the small feature abundances
-(MTD+SMF).
+[end-to-end metabolomics data
+workflow](https://rformassspectrometry.github.io/metabonaut/articles/end-to-end-untargeted-metabolomics.html)
+in mzTab-M format. The original MS data is available in the Metabolights
+repository with accession *MTBLS8735*. After collecting all necessary
+experimental metadata, we export this result object as a mzTab-M file with only
+the metadata and the small feature abundances (MTD+SMF).
 
 ```{r import}
 ## load preprocessed dataset
 se <- readObject(system.file("extdata", "preprocessed_res",
-                               package = "Metabonaut"))
+                             package = "Metabonaut"))
 ```
 
-## Creation of MzTabM object
+## Creation of the `MzTabM` object
 
 The *RmzTabM* package defines a `MzTabM()` convenience function to create a
 mzTab-M file from a `SummarizedExperiment` object. Information provided in such
 objects is automatically converted and formatted into content for the right
 mzTab-M section. The user simply needs to define the columns containing
-information for the various mzTab-M fields and a mzTab-M is compiled. This
-MzTabM object should then be completed adding any missing data.
+information for the various mzTab-M fields and a mzTab-M is compiled. The
+resulting `MzTabM` object should then be manually completed adding eventually missing data.
 
 ### Define missing data set's metadata (MTD)
 
 Comprehensive data set descriptions and metadata are important to enable re-use
 of the data and follow FAIR principles. The mzTab-M format has stringent
-requirement for mandatory fields and their format. Most of the fields are CV
-parameters and the **PSI Mass Spectrometry Controlled Vocabulary (PSI-MS)** is
-the primary CV used to annotate mass spectrometry-specific fields in mzTab-M.
-It was built collaboratively by MS software vendors and academic groups working
-in mass spectrometry and MS informatics. The CV is community-maintained: new
-terms can be requested through the PSI-MS mailing list. For more details see
-the [mzTab-M specification, section 4.2 "The PSI Mass Spectrometry Controlled
-Vocabulary (CV)"](https://hupo-psi.github.io/mzTab-M/mztabm/2.1/developers/specification.html#the-psi-mass-spectrometry-controlled-vocabulary-cv).
-We need to add/adapt some columns of the `SummarizedExperiment`'s `colData()`
-to complete or match the expected format:
+requirements for mandatory fields and their format. Most of the fields are
+controlled vocabulary (CV) parameters and the **PSI Mass Spectrometry Controlled
+Vocabulary (PSI-MS)** is the primary CV used to annotate mass
+spectrometry-specific fields in mzTab-M. It was built collaboratively by MS
+software vendors and academic groups working in mass spectrometry and MS
+informatics. The CV is community-maintained: new terms can be requested through
+the PSI-MS mailing list. For more details see the [mzTab-M specification,
+section 4.2 "The PSI Mass Spectrometry Controlled Vocabulary
+(CV)"](https://hupo-psi.github.io/mzTab-M/mztabm/2.1/developers/specification.html#the-psi-mass-spectrometry-controlled-vocabulary-cv).
+
+We need to add/adapt some columns of the `SummarizedExperiment`'s `colData()` to
+complete or match the expected format:
 
 - use a CV param for species: `"[NCBITaxon, NCBITaxon:9606, Homo sapiens, ]"`
 - use a CV param for blood plasma: `"[BTO, BTO:0000131, blood plasma, ]"`
@@ -152,12 +153,13 @@ parameters) for various controlled vocabularies.
 
 Now we can use the previous information to compile the data set's metadata. To
 this end we define the column names in the `SummarizedExperiment`'s `colData()`
-that contain information for sample, measurement run and assay mzTab-M fields.
-This mapping of mzTab-M fields to column names can be defined with the
-`sampleCols()`, `msRunCols()` and `assayCols()` helper functions. We use for
-example the content of the column `"sample_name"` for the mzTab-M *sample* name.
-Content from the `colData()` columns `"species"`, `"tissue"` and `"sample_type"`
-is used for mzTab-M sample fields `species`, `tissue` and `sample_type`.
+that contain information for the *sample*, *measurement run* and *assay* mzTab-M
+fields. This mapping of mzTab-M fields to column names can be defined with the
+`sampleCols()`, `msRunCols()` and `assayCols()` helper functions,
+respectively. In our example we use the content of column `"sample_name"` as
+the mzTab-M *sample* name. Content from the `colData()` columns `"species"`,
+`"tissue"` and `"sample_type"` is used for mzTab-M sample fields *species*`,
+*tissue* and *sample_type*.
 
 ```{r sampleCols}
 ## define mapping of `colData()` column names to mzTab-M sample fields
@@ -176,7 +178,7 @@ acols <- assayCols(assay = "derived_spectra_data_file")
 ```
 
 The column `"derived_spectra_data_file"` contains the MS data file name which we
-use both to define the MS runs and assays (assuming thus a 1:1 mapping between
+use to define both the MS runs and assays (assuming thus a 1:1 mapping between
 them).
 
 ```{r file-location}
@@ -186,7 +188,7 @@ colData(se)$derived_spectra_data_file
 At last we define also the study variables of the experiment. These can be
 technical characteristics or phenotype(s) of the samples. The present experiment
 consists of plasma samples of individuals with or without a cardiovascular
-disease (CVD) and repeated measurements of an external (serum) sample pools that
+disease (CVD) and repeated measurements of an external (serum) sample pool that
 was used as quality control sample. These are defined in `colData()` columns
 `"blood_sample_type"`, `"age"` and `"phenotype"`.
 
@@ -195,10 +197,10 @@ colData(se)[, c("blood_sample_type", "phenotype", "age")] |>
     kable(format = "pipe")
 ```
 
-With this information defined we can use the `MzTabM()` function to create a
-template mzTab-M for the present experiment. Parameter `groups` defines the
-column names of the `SummarizedExperiment`'s `colData()` to be used as mzTab-M
-*study variable groups*.
+We can now use the `MzTabM()` function to create a template mzTab-M for the
+present experiment. Parameter `groups` defines the column names of the
+`SummarizedExperiment`'s `colData()` that represent the mzTab-M *study variable
+groups* (i.e., the sample's phenotype or technical characteristics).
 
 ```{r MzTabM-MTD-obj}
 mzt <- MzTabM(se, id = "MTBLS8735", sampleCols = scols,
@@ -209,34 +211,34 @@ mzt
 
 This `MzTabM` object contains only metadata information, but no
 abundances/feature data yet. Also, some general metadata are still missing and,
-if exported to a mzTab-M file, it might not yet validate. We are next adding the
+if exported to a mzTab-M file, it might not yet validate. We add next the
 small molecule feature (SMF) content and, in the subsequent section *Completing
-the metadata content*, adding any missing required metadata fields.
+the metadata content*, add any missing required metadata fields.
 
 ### Add feature abundance matrix (SMF)
 
 We next add feature abundance information to the mzTab-M. While the abundance
 values can be taken from one of the `assay()`s from the `SummarizedExperiment`,
-we need to provide also feature characteristics. These are usually available in
+we need also to provide feature characteristics. These are usually available in
 the `SummarizedExperiment`s `rowData()`:
 
 ```{r feature-table}
 rowData(se) |> head() |> kable(format = "pipe")
 ```
 
-For our example we use column `"mzmed"` which defines the features median *m/z*
-value which can be mapped to the SMF field *exp_mass_to_charge* and `"rtmed"`
-that reports the median retention time of the feature which can be used for the
-SMF field *retention_time_in_seconds*. We will in addition add an optional field
-*feature_id* to report and add the IDs of the individual features from the
-`SummarizedExperiment`, which we add as a column `"feature_id"` to the
-`rowData()`:
+For our example we use column `"mzmed"` which provides the features' median
+*m/z* value and which we map to the SMF field *exp_mass_to_charge*. Similarly,
+we use column `"rtmed"` with the median retention time of the feature and map
+that to the SMF field *retention_time_in_seconds*. We in addition add an
+optional field *feature_id* to report and add the IDs of the individual features
+from the `SummarizedExperiment`. Below we first add this information as a new
+column `"feature_id"` to the `rowData()`:
 
 ```{r feature-id}
 rowData(se)$feature_id <- rownames(se)
 ```
 
-Similar to the metadata column mappings above, we define a mapping of SMF
+Similar to the previous metadata column mappings, we define a mapping of SMF
 fields to `rowData()` columns using the `smfCols()` helper function:
 
 ```{r smfCols}
@@ -247,8 +249,8 @@ smf_cols <- smfCols(exp_mass_to_charge = "mzmed",
 
 Providing these additional SMF mapping in the `MzTabM()` call above will compile
 a `MzTabM` object with an MTD and SMF section from the
-`SummarizedExperiment`. Parameter `assayName` defines which of the
-`SummarizedExperiment`'s assays will be used the SMF section.
+`SummarizedExperiment`. Parameter `assayName` defines which of the available
+assays in the `SummarizedExperiment` will be used for the SMF section.
 
 ```{r MzTabM-MTD-SMF-obj}
 ## Create a MTD+SMF MzTabM object from the SummarizedExperiment
@@ -265,8 +267,8 @@ extract the SMF table from the `SummarizedExperiment` and add that manually to
 the `MzTabM` object.
 :::
 
-This `mzt` variable now contains the mzTab-M content that could be extracted
-from the `SummarizedExperiment`. The first rows of the metadata section are:
+This `mzt` variable now contains the mzTab-M content extracted from the
+`SummarizedExperiment`. The first rows of the metadata section are:
 
 ```{r mtd}
 mtd(mzt) |> head() |> kable(format = "pipe", col.names = c("Field", "Value"))
@@ -278,18 +280,18 @@ And the first lines of the SMF section:
 smf(mzt) |> head() |> kable(format = "pipe")
 ```
 
-The object now has MTD and SMF sections, but some required metadata still must
-be added manually before export. In the next section we will complete the data
-adding some metadata fields that could not be derived from the result object.
+While the object has MTD and SMF sections, some metadata still must be added
+manually to generate a complete mzTab-M file.
 
 ### Completing the metadata content
 
 Some of the metadata information must be manually added, because it can not be
-extracted from the `SummarizedExperiment`. This depends also on the information
-compiled into the mzTab-M file. We used for example the *BTO* and *NCBITaxon*
-ontologies to describe the samples, but these two are not added by default. The
-`getMtdCv()` function can be used to get the set of defined
-controlled vocabularies (ontologies) in the `MzTabM` object:
+extracted from the `SummarizedExperiment`. Which metadata needs to be added
+depends on experimental settings and the type of data and variables present in
+the `MzTabM` object. We used for example the *BTO* and *NCBITaxon* ontologies to
+describe the samples, but these two CVs are not added by default. To get the
+controlled vocabularies that are already defined in the `MzTabM` object we can
+use the `getMtdCv()` function.
 
 ```{r get-CV}
 getMtdCv(mzt) |> kable(format = "pipe", col.names = c("Field", "Value"))
@@ -309,7 +311,8 @@ mzt <- setMtdCv(mzt,
                         "https://www.ebi.ac.uk/ols4/ontologies/ncbitaxon"))
 ```
 
-Also, we add *xcms* as software to the `MzTabM`:
+Also, since the preprocessing was performed using *xcms*, we add it as
+*software* to the `MzTabM`:
 
 ```{r set-software}
 mzt <- setMtdField(mzt, "software", "[MS, MS:1001582, xcms, 4.10.0]")
@@ -344,7 +347,7 @@ Now we have a complete mzTab-M content compiled and can proceed to export it.
 
 ## Export MzTabM object to an mzTab-M file
 
-The MzTabM object, containing the MTD and SMF sections, is ready for export to
+The `MzTabM` object, containing the MTD and SMF sections, is ready for export to
 an mzTab-M file. Following generation, the file is verified using the mzTab-M
 validator.
 
@@ -352,10 +355,9 @@ validator.
 writeMzTabM(mzt, path = file.path(tempdir(), "MTBLS8735_mtd_smf.mzTab"))
 ```
 
+# Import of a `SummarizedExperiment` from mzTab-M
 
-# Import of a SummarizedExperiment from mzTab-M file
-
-The mzTab-M file generated above can be read back into R using the
+The above generated mzTab-M file can also be read back into R using the
 `readMzTabM()` function. The file is verified using the mzTab-M validator and
 loaded into a `MzTabM` object.
 
@@ -366,13 +368,13 @@ mzt_r
 
 Now we have a `MzTabM` object with the MTD and SMF sections loaded. To make it
 easier to work with the data, we can convert it to a `SummarizedExperiment`
-object using the `makeSummarizedExperimentFromMzTabM()` function.
-By default, the function will use as feature IDs the values in the columns
-`SMF_ID` and keep the column names of the `rowData` as reported in the SMF
-header. In this case, we want to use the original feature IDs from the
-`rowData` of the `SummarizedExperiment` object that are in the optional SMF
-field `opt_global_feature_id`. We also specify the mapping of the SMF fields to
-the original `rowData` columns using the `smfCols` define above.
+object using the `makeSummarizedExperimentFromMzTabM()` function.  By default,
+the function will use the content of column `SMF_ID` as feature IDs and keep the
+column names of the `rowData` as reported in the SMF header. In this case, we
+want to use the original feature IDs from the `rowData` of the
+`SummarizedExperiment` object that are in the optional SMF field
+`opt_global_feature_id`. We also specify the mapping of the SMF fields to the
+original `rowData` columns using the `smfCols` define above.
 
 ```{r MzTabM-to-SE}
 se_r <- makeSummarizedExperimentFromMzTabM(
@@ -384,10 +386,10 @@ se_r <- makeSummarizedExperimentFromMzTabM(
 se_r
 ```
 
-The reconstructed `SummarizedExperiment` contains the same measurement data.
-Differences in `rowData` and `colData` reflect that only fields present in the
-SMF and MTD sections are loaded and that column names follow the mzTab-M
-specification.
+The reconstructed `SummarizedExperiment` contains the same abundance data as the
+original one. Differences in the `SummarizedExperiment`'s `rowData()` and
+`colData()` depend on which columns were exported and to which mzTab-M fields
+they were converted/mapped.
 
 # Outlook
 
@@ -402,20 +404,20 @@ this matters:
   of software.
 
 - *Reproducibility and Reuse*: A self-contained, well-documented results file
-  makes it much easier for others to understand exactly how a set of features,
-  identifications, and quantification values were derived.
+  makes it much easier for other researchers to understand exactly how a set of
+  features, identifications, and quantification values were derived.
 
 - *FAIR Data*: Exporting directly to this format lowers the barrier to sharing
   data following the FAIR principles, which in turn supports meta-analyses and
   the reuse of published datasets. It also simplifies the submission process
   for new datasets to online repositories.
 
-At present, this package supports the import and export of mzTab-M files as
-`SummarizedExperiment` objects. The next step is to support exporting mzTab-M
-directly from `xcms` result objects, without an intermediate manual conversion
-step. This would make it straightforward to go from raw data processing in
-`xcms` to a deposition- or exchange-ready mzTab-M file in a single,
-reproducible pipeline.
+At present, this `r Biocpkg("RmzTabM")` supports the import and export of
+mzTab-M files as `SummarizedExperiment` objects. The next step is to support
+exporting mzTab-M directly from `r Biocpkg("xcms")` result objects, without an
+intermediate manual conversion step. This would make it straightforward to go
+from raw data processing in *xcms* to a deposition- or exchange-ready mzTab-M
+file in a single, reproducible pipeline.
 
 # Session information
 

--- a/vignettes/install_v0.qmd
+++ b/vignettes/install_v0.qmd
@@ -10,7 +10,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-For manual installation, an [R](https://www.r-project.org/) version \>= 4.4.0 is
+For manual installation, an [R](https://www.r-project.org/) version \>= 4.6.0 is
 required.
 
 # Running workflows in the cloud
@@ -33,13 +33,14 @@ the workshop is stopped, so download a local copy of anything you want to keep.
 
 # Running workflows locally
 
-To install on your computer all the packages necessary for the workflows run the
-code as follow:
+To install all the packages required to run the workflows locally run the
+code as follow in an R session (R >= 4.6.0):
 
 ```{r eval=FALSE}
 install.packages("BiocManager")
-BiocManager::install('RforMassSpectrometry/MsIO', ask = FALSE,
-                     dependencies = TRUE)
+BiocManager::install(
+    "RforMassSpectrometry/MsIO@a669fa1303a023161581b7a16caed3ed20a43299",
+    ask = FALSE, dependencies = TRUE)
 
 BiocManager::install("RforMassSpectrometry/Metabonaut",
                      dependencies = TRUE, ask = FALSE, update = TRUE)
@@ -56,10 +57,16 @@ gitcreds::gitcreds_get()
 gitcreds::gitcreds_delete()
 ```
 
+The workflow source files (quarto and Rmarkdown documents) can be downloaded
+from Metabonaut's GitHub
+[repository](https://github.com/RforMassSpectrometry/Metabonaut) (download
+either individual files from the *vignettes* folder, or the full repository).
+
 # Docker image
 
 The vignettes files along with an R runtime environment including all required
-packages and the RStudio (Posit) editor are all bundled in a *docker* container.
+packages and data as well as the RStudio (Posit) editor are all bundled in a
+*docker* container.
 
 After installation, this docker container can be run on the computer and the
 code and examples from the vignettes can be evaluated within this environment
@@ -71,15 +78,22 @@ code and examples from the vignettes can be evaluated within this environment
     image](https://hub.docker.com/r/rformassspectrometry/metabonaut) of this
     tutorial e.g. from the command line with:
 
-```         
-docker pull rformassspectrometry/metabonaut:latest
 ```
+docker pull rformassspectrometry/metabonaut:RELEASE_3_23
+```
+
+::: {.callout-note appearance = "minimal"}
+ℹ️ the tag *RELEASE_3_23* selects the docker image specific for Bioconductor
+release 3.23. Docker images for upcoming Bioconductor releases will be made
+available using a different tag (e.g. RELEASE_3_24) ensuring this version of the
+image will be available also in future.
+:::
 
 -   Start the docker container, either through the Docker Desktop, or on the
     command line with
 
-```         
-docker run -e PASSWORD=bioc -p 8787:8787 rformassspectrometry/metabonaut:latest
+```
+docker run -e PASSWORD=bioc -p 8787:8787 rformassspectrometry/metabonaut:RELEASE_3_23
 ```
 
 -   Enter [`http://localhost:8787`](http://localhost:8787) in a web browser and

--- a/vignettes/install_v0.qmd
+++ b/vignettes/install_v0.qmd
@@ -79,21 +79,21 @@ code and examples from the vignettes can be evaluated within this environment
     tutorial e.g. from the command line with:
 
 ```
-docker pull rformassspectrometry/metabonaut:RELEASE_3_23
+docker pull rformassspectrometry/metabonaut:v1.6.2
 ```
 
 ::: {.callout-note appearance = "minimal"}
-ℹ️ the tag *RELEASE_3_23* selects the docker image specific for Bioconductor
-release 3.23. Docker images for upcoming Bioconductor releases will be made
-available using a different tag (e.g. RELEASE_3_24) ensuring this version of the
-image will be available also in future.
+ℹ️ the tag *v1.6.2* selects the docker image specific for Metabonaut version
+1.6.2. Docker images for upcoming versions releases will be made available using
+a different tag (e.g. v1.6.3) ensuring images from older versions will also be
+available in future.
 :::
 
 -   Start the docker container, either through the Docker Desktop, or on the
     command line with
 
 ```
-docker run -e PASSWORD=bioc -p 8787:8787 rformassspectrometry/metabonaut:RELEASE_3_23
+docker run -e PASSWORD=bioc -p 8787:8787 rformassspectrometry/metabonaut:v1.6.2
 ```
 
 -   Enter [`http://localhost:8787`](http://localhost:8787) in a web browser and

--- a/vignettes/large-scale-analysis.Rmd.orig
+++ b/vignettes/large-scale-analysis.Rmd.orig
@@ -319,7 +319,7 @@ data sets, also on conventional computing infrastructure (e.g. laptop). With
 time. Peak detection is then performed in parallel on 8 CPUs using our
 predefined default parallel processing setup.
 
-```{r, eval = eval_preprocess}
+```{r find-chrom-peaks, eval = eval_preprocess}
 cwp <- CentWaveParam(ppm = 25,
                      peakwidth = c(2, 20),
                      prefilter = c(3, 500),
@@ -339,7 +339,7 @@ Memory usage and time elapsed for this processing step where:
 ```{r, results = "asis", eval = eval_preprocess}
 tmp <- data.frame(
     `Peak RAM [MiB]` = p$Peak_RAM_Used_MiB,
-    `Processing time [min]` = p$Elapsed_Time_sec / 60,
+    `Processing time [hours]` = p$Elapsed_Time_sec / 60 / 60,
     check.names = FALSE)
 pandoc.table(
     tmp, style = "rmarkdown", split.table = Inf,
@@ -408,7 +408,7 @@ detection artifacts, such as duplicated peaks, overlapping peaks or artificially
 split peaks. Again, we process the data in chunks of 8 data files at a time to
 keep memory usage manageable for the used computer system.
 
-```{r, eval = eval_preprocess}
+```{r merge-neighboring-peaks, eval = eval_preprocess}
 #' Perform peak refinement
 mnpp <- MergeNeighboringPeaksParam(expandRt = 5)
 
@@ -465,7 +465,7 @@ pandoc.table(
 We can next perform the retention time alignment using the *peak groups*
 method.
 
-```{r, eval = eval_preprocess}
+```{r adjust-rtime, eval = eval_preprocess}
 pgp <- PeakGroupsParam(minFraction = 0.8, extraPeaks = 100,
                        span = 0.5)
 #' Perform the alignment
@@ -512,7 +512,7 @@ chromatographic peaks across samples and define the *LC-MS features*. We reduce
 `minFraction` parameter to also define features if chromatographic peaks were
 only present in 30% of the samples and use a more stringent `bw` parameter.
 
-```{r, eval = eval_preprocess}
+```{r group-chrom-peaks, eval = eval_preprocess}
 pdp <- PeakDensityParam(sampleGroups = rep(1L, length(twins)),
                         minFraction = 0.3,
                         binSize = 0.01,
@@ -589,7 +589,7 @@ features for which in some samples no chromatographic peak was detected (and for
 which hence a missing value is reported). Here we can again benefit from
 chunk-wise parallel processing.
 
-```{r, eval = eval_preprocess}
+```{r fill-chrom-peaks, eval = eval_preprocess}
 #' Perform the gap filling
 cpap <- ChromPeakAreaParam()
 
@@ -632,7 +632,10 @@ The results from the preprocessing could now be converted to a
 analysis e.g. by performing further data exploration, normalization or
 statistical data analysis.
 
-
+```{r save-results, echo = FALSE}
+## Silently saving results for eventual later evaluation
+save(twins, file = "twins.RData")
+```
 
 # Performance evaluation
 
@@ -680,7 +683,7 @@ We next execute the performance tests. To use the new `XcmsExperimentHdf5`, we
 need to specify the path and file name of the HDF5 file where the results should
 be stored to.
 
-```{r, eval = eval_performance}
+```{r performance-peak-detect, eval = eval_performance}
 #' Settings
 cwp <- CentWaveParam(ppm = 25,
                      peakwidth = c(2, 20),
@@ -762,7 +765,7 @@ the associated HDF5 files. To perform the peak refinement on the same initial
 data we thus need to create copies of the original HDF5 file for each
 configuration.
 
-```{r, eval = eval_performance}
+```{r performance-refine-chrom-peaks, eval = eval_performance}
 #' Settings
 mnpp <- MergeNeighboringPeaksParam(expandRt = 5)
 
@@ -836,7 +839,7 @@ analysis and does thus not support the `chunkSize` parameter nor does it support
 parallel processing. We thus only compare the performance of in-memory and
 on-disk results below.
 
-```{r, eval = eval_performance}
+```{r performance-group-chrom-peaks, eval = eval_performance}
 #' Settings
 pdp <- PeakDensityParam(sampleGroups = rep(1, length(tsub)),
                         minFraction = 0.3,
@@ -876,7 +879,7 @@ Next we evaluate the performance of the retention time alignment step using the
 *peak groups* approach. This method relies on the peak detection and
 correspondence results and does not support parallel processing.
 
-```{r, eval = eval_performance}
+```{r performance-adjust-rtime, eval = eval_performance}
 #' Settings
 pgp <- PeakGroupsParam(minFraction = 0.9, extraPeaks = 1000,
                        span = 0.5)
@@ -901,7 +904,7 @@ pandoc.table(
                      "retention time alignment analysis."))
 ```
 
-```{r, echo = FALSE, message = FALSE, eval = eval_performance}
+```{r performance-group-chrom-peaks2, echo = FALSE, message = FALSE, eval = eval_performance}
 #' Silently performing alignment for all HDF5 result objects
 t2 <- adjustRtime(t2, param = pgp)
 t4 <- adjustRtime(t4, param = pgp)
@@ -922,7 +925,7 @@ Finally we evaluate the performance of the gap-filling step. This method
 requires access to the full MS data and can thus again be configured with the
 `chunkSize` parameter and different parallel processing setups.
 
-```{r, eval = eval_performance}
+```{r performance-fill-chrom-peaks, eval = eval_performance}
 #' Settings
 cpap <- ChromPeakAreaParam()
 


### PR DESCRIPTION
- Update Dockerfile to fix versions for packages installed only through GitHub (because they are not yet available in Bioconductor) issue #73 ; revert install of *SpectriPy* to install from Bioconductor.
- Update README and installation instructions to clarify users should install a docker image with a certain release tag (instead of *Iatest*).
- Small updates in the large scale vignette.